### PR TITLE
Make CI run composer-lint before running composer-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ show-current-target = @echo; echo "======= $@ ========"
 analyze: install composer-analyze
 
 .PHONY: ci
-ci: install composer-test npm-test
+ci: install composer-lint composer-test npm-test
 
 .PHONY: ci-coverage
 ci-coverage: install composer-test-coverage npm-test-coverage
@@ -129,6 +129,11 @@ ifdef COMPOSER_EXT
 endif
 
 # ======== Test Targets ========
+
+.PHONY: composer-lint
+composer-lint: .init
+	$(show-current-target)
+	$(compose-exec-wiki) bash -c "cd $(EXTENSION_FOLDER) && composer lint"
 
 .PHONY: composer-test
 composer-test: .init


### PR DESCRIPTION
The php code should be linted before composer test is run.