### PR TITLE
Allow setting DB_OPTION for mysql/mariadb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ IMAGE_NAME := $(extension):test-$(MW_VERSION)-$(SMW_VERSION) # ggf hier Timestam
 # ======== CI ENV Variables ========
 DB_TYPE ?= sqlite
 DB_IMAGE ?= ""
+DB_OPTION ?= ""
 MW_INSTALL_PATH ?= /var/www/html
 
 environment = \

--- a/README.adoc
+++ b/README.adoc
@@ -115,6 +115,7 @@ Extensions usually required by other extensions are already included and can be 
 | PHP_VERSION | https://hub.docker.com/r/gesinn/mediawiki-ci/tags[Docker image PHP Version]
 | DB_TYPE | Database type (mysql, postgres, sqlite)
 | DB_IMAGE | Database Docker image (mysql and postgres only), for example `mysql:5`
+| DB_OPTION | Additional command line options passed to the database server (e.g. --innodb-snapshot-isolation=0 for MariaDB ≥11.6)
 | EXTENSION | The name of the extension being tested/CI'ed
 | COMPOSER_EXT | `true` or `false`. Enables "composer update" inside of extension.
 | NODE_JS | `true` or `false`. Enables node.js related tests and "npm install"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     image: ${DB_IMAGE:-mysql:5}
     environment:
       - MYSQL_ROOT_PASSWORD=database
+    command: ${DB_OPTION:-}
     profiles:
       - mysql
 
@@ -46,3 +47,4 @@ services:
     image: mintel/docker-wait-for-it
     profiles:
       - no-up
+


### PR DESCRIPTION
We need to set --innodb-snapshot-isolation=OFF for MariaDB 11.8 due to https://phabricator.wikimedia.org/T388337